### PR TITLE
v8 include directives paths generalized

### DIFF
--- a/Sources/debug.cpp
+++ b/Sources/debug.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 #include "debug.h"
 #include "debug_server.h"
-#include "../V8/include/v8-debug.h"
+#include <v8-debug.h>
 #include <v8-inspector.h>
 #include "pch.h"
 #include <Kore/Threads/Thread.h>

--- a/Sources/debug.h
+++ b/Sources/debug.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "semaphore.h"
-#include "../V8/include/v8.h"
+#include <v8.h>
 
 void startDebugger(v8::Isolate* isolate, int port);
 bool tickDebugger();

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -22,8 +22,8 @@
 
 #include "debug.h"
 
-#include "../V8/include/libplatform/libplatform.h"
-#include "../V8/include/v8.h"
+#include <libplatform/libplatform.h>
+#include <v8.h>
 #include <v8-inspector.h>
 
 #include <stdio.h>


### PR DESCRIPTION
I was trying to build Krom with different includes-libs in koremake.js and found this issue with "unresolved external symbol"