### PR TITLE
Center window

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -113,9 +113,9 @@ namespace {
 		options.title = *title;
 		options.width = width;
 		options.height = height;
-		options.x = 100;
-		options.y = 100;
-		options.targetDisplay = 0;
+		options.x = -1;
+		options.y = -1;
+		options.targetDisplay = -1;
 		options.showWindow = !nowindow;
 		Kore::System::setShowWindowFlag(options.showWindow);
 		options.vSync = vSync;


### PR DESCRIPTION
Unifies behaviour with [Kha/Kore](https://github.com/Kode/Kha/blob/master/Backends/Kore/main.cpp#L337), centers the window and fixes fullscreen mode.

On Windows, I had to set `options.targetDisplay` to `-1`(same like Kha does), otherwise Kore fails to retrieve primary display size somehow.