### PR TITLE
Fixes crashes on quitting

### DIFF
--- a/Sources/debug.cpp
+++ b/Sources/debug.cpp
@@ -120,6 +120,10 @@ void startDebugger(v8::Isolate* isolate, int port) {
 	v8inspector->contextCreated(v8_inspector::V8ContextInfo(globalContext.Get(isolate), 0, v8_inspector::StringView()));
 }
 
+void stopDebugger() {
+	v8inspector.reset();
+}
+
 bool tickDebugger() {
 	v8::Locker locker{ isolate };
 

--- a/Sources/debug.h
+++ b/Sources/debug.h
@@ -5,5 +5,6 @@
 
 void startDebugger(v8::Isolate* isolate, int port);
 bool tickDebugger();
+void stopDebugger();
 
 extern bool messageLoopPaused;

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -2130,6 +2130,17 @@ namespace {
 
 	void endV8() {
 		updateFunction.Reset();
+		dropFilesFunction.Reset();
+		keyboardDownFunction.Reset();
+		keyboardUpFunction.Reset();
+		keyboardPressFunction.Reset();
+		mouseDownFunction.Reset();
+		mouseUpFunction.Reset();
+		mouseMoveFunction.Reset();
+		mouseWheelFunction.Reset();
+		gamepadAxisFunction.Reset();
+		gamepadButtonFunction.Reset();
+		audioFunction.Reset();
 		globalContext.Reset();
 		isolate->Dispose();
 		V8::Dispose();
@@ -2871,8 +2882,13 @@ int kore(int argc, char** argv) {
 	startKrom(code);
 	Kore::System::start();
 
-	exit(0); // TODO
+	if (!nosound) {
+		Kore::Audio2::shutdown();
+	}
 
+	if (debugMode) {
+		stopDebugger();
+	}
 	endV8();
 
 	return 0;


### PR DESCRIPTION
Fixes the crashes described in https://github.com/Kode/Krom/issues/76, which are due to:

- the audio thread calling into V8 after it's been already destroyed
- the V8 `Global` destructor running in the application shutdown after `exit()`, which crashes on macOS 

**EDIT** Tested on d14d0d66 (currently packaged KodeStudio version), since master doesn't work at all on macOS currently due to Metal issues. Works fine now on d14d0d66 though.