### PR TITLE
Reenable --watch

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -2794,12 +2794,18 @@ int kore(int argc, char** argv) {
 #endif
 	assetsdir = argc > 1 ? argv[1] : bindir;
 	shadersdir = argc > 2 ? argv[2] : bindir;
+	
+	int optionIndex = 3;
+	if (shadersdir.rfind("--", 0) == 0) {
+		shadersdir = bindir;
+		optionIndex = 2;
+	}
 
 	bool readStdoutPath = false;
 	bool readConsolePid = false;
 	bool readPort = false;
 	int port = 0;
-	for (int i = 3; i < argc; ++i) {
+	for (int i = optionIndex; i < argc; ++i) {
 		if (readPort) {
 			port = atoi(argv[i]);
 			readPort = false;
@@ -2809,7 +2815,7 @@ int kore(int argc, char** argv) {
 			readPort = true;
 		}
 		else if (strcmp(argv[i], "--watch") == 0) {
-			//**watch = true;
+			watch = true;
 		}
 		else if (strcmp(argv[i], "--nosound") == 0) {
 			nosound = true;
@@ -2859,7 +2865,8 @@ int kore(int argc, char** argv) {
 	Kore::threadsInit();
 
 	if (watch) {
-		watchDirectories(argv[1], argv[2]);
+		std::string path1(assetsdir), path2(shadersdir);
+		watchDirectories(&path1[0], &path2[0]);
 	}
 
 	if (debugMode) {


### PR DESCRIPTION
`--watch` in Krom is currently ignored. I'm not sure why, it works great.

It would also be great, if "krom path --watch" would work (without providing a shader dir).

Since `watchDirectories` might change its parameters, I thought it wise to copy the strings.