### PR TITLE
Attempt to show exception message

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -2470,8 +2470,15 @@ namespace {
 			size_t length;
 			JsCopyString(sourceObj, source, 1023, &length);
 			source[length] = 0;
+			JsValueRef exceptionObj;
+			JsGetProperty(meta, getId("exception"), &exceptionObj);
+			JsValueRef messageObj;
+			JsGetProperty(exceptionObj, getId("message"), &messageObj);
+			char message[1024];
+			JsCopyString(messageObj, message, 1023, &length);
+			message[length] = 0;
 
-			Kore::log(Kore::Error, "Exception at line %i: %s\n", line, source);
+			Kore::log(Kore::Error, "Exception at line %i: %s - %s\n", line, source, message);
 		}
 	}
 


### PR DESCRIPTION
This does not work yet. The goal is to show exception message like `Unable to get property 'blend' of undefined or null reference`.

Right now the `meta.exception.message` string appears to be empty, however `meta.exception.name` properly shows `TypeError`.

References:
- https://github.com/Microsoft/Chakra-Samples/blob/master/ChakraCore%20Samples/JSRT%20Hosting%20Samples/C%2B%2B/ChakraCoreHost/ChakraCoreHost.cpp#L300
- https://github.com/Microsoft/ChakraCore/wiki/JavaScript-Runtime-%28JSRT%29-Overview#exception-handling
- https://github.com/Microsoft/ChakraCore/wiki/JsGetAndClearExceptionWithMetadata