### PR TITLE
Add a "Build Krom" Task For VSCode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Build Krom",
+			"group": "build",
+			"type": "shell",
+			"windows": {
+				"command": "node Kore/make --compiler clang --compile"
+			},
+			"linux": {
+				"command": "node Kore/make --compiler clang --compile",
+			},
+			"osx": {
+				"command": "node Kore/make --noshaders"
+			},
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"panel": "dedicated",
+				"focus": true,
+				"showReuseMessage": true
+			},
+			"problemMatcher": []
+		}
+	]
+}


### PR DESCRIPTION
Build commands set per platform as documented in the Readme. Only actually tested on Linux.