### PR TITLE
Print exception message

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -2627,13 +2627,8 @@ namespace {
 			JsGetProperty(meta, getId("exception"), &exceptionObj);
 			char buf[2048];
 			size_t length;
-			
-			JsValueRef messageObj;
-			JsGetProperty(exceptionObj, getId("message"), &messageObj);
-			JsCopyString(messageObj, buf, 2047, &length);
-			buf[length] = 0;
-			sendLogMessage("Uncaught exception: %s", buf);
 
+			sendLogMessage("Uncaught exception:");
 			JsValueRef sourceObj;
 			JsGetProperty(meta, getId("source"), &sourceObj);
 			JsCopyString(sourceObj, nullptr, 0, &length);
@@ -2658,7 +2653,7 @@ namespace {
 			if (length < 2048) {
 				JsCopyString(stackObj, buf, 2047, &length);
 				buf[length] = 0;
-				sendLogMessage("%s", buf);
+				sendLogMessage("%s\n", buf);
 			}
 		}
 	}


### PR DESCRIPTION
Krom prints a pretty exception message again.
```
Uncaught exception:
        a.b = 1;
        ^
TypeError: Unable to set property 'b' of undefined or null reference
   at Main.main (krom.js:90:2)
```

The only cumbersome thing is that I am including the `jserr.rc2` file. Otherwise it is being generated
[here](https://github.com/Microsoft/ChakraCore/blob/3daa56768f45594ec3461731e68865323900acf1/lib/Parser/Chakra.Parser.vcxproj#L126), I am not sure if there is a nice way to automate that in korefile.

Depends on: https://github.com/Kode/koremake/pull/68, https://github.com/Kode/ChakraCore/pull/3.

Fixes https://github.com/Kode/Krom/issues/96.