### PR TITLE
minor changes

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -3441,7 +3441,7 @@ int kore(int argc, char** argv) {
 	}
 
 	if (!serialized && !reader.open("krom.js")) {
-		fprintf(stderr, "could not load krom.js. aborting.");
+		fprintf(stderr, "could not load krom.js. aborting.\n");
 		exit(1);
 	}
 

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -2774,7 +2774,7 @@ namespace {
 			for (int i = 0; i < len; i++) str[i] = filePath[i];
 			str[len] = 0;
 			JsCreateStringUtf16(str, len, &args[1]);
-			delete str;
+			delete[] str;
 		}
 		JsValueRef result;
 		JsCallFunction(dropFilesFunction, args, 2, &result);


### PR DESCRIPTION
- removes a compile warning b/c of wrong delete call
- adds a newline to the error message in case there is no script found, so the console doesn't look messed up anymore
  - `could not load krom.js. aborting.dklein@CLDEV10:~/kode/Krom/Deployment$ `